### PR TITLE
Python version info should be taken from sys.version_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 version = '0.1'
 PACKAGE_NAME = 'jot'
 
-if sys.version < '2.6' or sys.version >= '3.0':
+if sys.version_info < (2, 6) or sys.version_info >= (3, 0):
     print >>sys.stderr, '%s requires Python >= 2.6 and < 3.0' % PACKAGE_NAME
     sys.exit(1)
 


### PR DESCRIPTION
Version information should be taken from `sys.version_info` as those are numeric values. The `sys.version` version string is not guaranteed to start with the Python version across Python interpreters.
